### PR TITLE
Antigen environment variables must be set before source-ing antigen.zsh

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -3,12 +3,12 @@
 ANTIGEN=$HOME/.antigen
 DOTFILES=$HOME/.dotfiles
 
-# Load Antigen
-source $ANTIGEN/antigen.zsh
-
 # Configure Antigen
 declare -a ANTIGEN_CHECK_FILES
 ANTIGEN_CHECK_FILES=($HOME/.zshrc $HOME/.zshrc.local)
+
+# Load Antigen
+source $ANTIGEN/antigen.zsh
 
 # Load the oh-my-zsh's library
 antigen use oh-my-zsh


### PR DESCRIPTION
According to official documents [Section Configuration](https://github.com/zsh-users/antigen/wiki/Configuration).

> The following environment variables can be set to customize the behavior of Antigen. Make sure you set them *before* source-ing `antigen.zsh`.
> ...
> ### Optimizations
> ...
> `ANTIGEN_CHECK_FILES` — Use this configuration to tell Antigen which files to check for configuration changes, this is to avoid doing `antigen-reset` manually.
